### PR TITLE
Arreglo fallo en las tarjetas que muestran el tiempo por horas cuando el texto es muy largo

### DIFF
--- a/src/components/Current/CurrentHourCard.jsx
+++ b/src/components/Current/CurrentHourCard.jsx
@@ -6,7 +6,7 @@ import { useContext } from 'react'
 export default function CurrentHourCard({ element }) {
   const { degreeType } = useContext(WeatherContext)
   return (
-    <div className='w-28 h-44 mt-5 mr-1 inline-block border-[3px] bg-white dark:bg-slate-700 dark:border-slate-900 text-center'>
+    <div className='w-28 h-48 mt-5 mr-1 inline-block border-[3px] bg-white dark:bg-slate-700 dark:border-slate-900 text-center'>
       <div className='grid place-content-center place-items-center h-full '>
         <Img
           className='mt-1'
@@ -26,7 +26,7 @@ export default function CurrentHourCard({ element }) {
         <p className='dark:text-white font-bold text-base'>
           {degreeType === 'C' ? element.temp_c + 'ºC' : element.temp_f + 'ºF'}
         </p>
-        <p className='dark:text-white font-bold text-sm whitespace-pre-line h-10'>
+        <p className='dark:text-white font-bold text-sm whitespace-pre-line h-16'>
           {element.condition?.text}
         </p>
       </div>


### PR DESCRIPTION
Buenas 👋,

Cotilleando tu aplicacion … 😂 encontre el siguiente fallido con el texto que indica el estado del tiempo en las tarjetas que lo muestran cada hora. Te dejo un captura de pantalla para que lo puedas ver:

<img width="1237" alt="image" src="https://github.com/ikurotime/GeoWeather/assets/56631428/b22810df-b06d-46b5-af05-5c72f7ef947e">

Para arreglar este fallido simplemente, aumente la altura de las tarjetas y del p que contiene el texto.

Espero que sirva de ayuda !!!

Un saludo, muchas gracias